### PR TITLE
Bugfix one field query with bs record

### DIFF
--- a/src/bucklescript/output_bucklescript_decoder.re
+++ b/src/bucklescript/output_bucklescript_decoder.re
@@ -243,7 +243,11 @@ and generate_record_decoder = (config, loc, name, fields) => {
              Some(Pat.var({loc, txt: "field_" ++ field}))
            | Fr_fragment_spread(_) => None,
          )
-      |> Pat.tuple
+      |> (
+           fun
+           | [field_pattern] => field_pattern
+           | field_patterns => Pat.tuple(field_patterns)
+      )
     );
 
   let field_decoder_tuple =
@@ -279,7 +283,11 @@ and generate_record_decoder = (config, loc, name, fields) => {
              }
            | Fr_fragment_spread(_) => None,
          )
-      |> Exp.tuple
+      |> (
+           fun
+           | [field_decoder] => field_decoder
+           | field_decoders => Exp.tuple(field_decoders)
+      )
     );
 
   let record_fields =

--- a/tests_bucklescript/__tests__/record.re
+++ b/tests_bucklescript/__tests__/record.re
@@ -8,12 +8,24 @@ type dog = {
   barkVolume: float,
 };
 
+type oneFieldQuery = {nullableString: option(string)};
+
 module MyQuery = [%graphql
   {|
   {
     variousScalars @bsRecord {
       string
       int
+    }
+  }
+|}
+];
+
+module OneFieldQuery = [%graphql
+  {|
+  {
+    variousScalars @bsRecord {
+      nullableString
     }
   }
 |}
@@ -79,6 +91,18 @@ Jest.(
         ),
       )
       == {"variousScalars": expected};
+    });
+
+    test("Decodes a record with one field in a selection", () => {
+      let expected = {nullableString: Some("a string")};
+      expect(
+        OneFieldQuery.parse(
+          Js.Json.parseExn(
+            {|{"variousScalars": {"nullableString": "a string"}}|},
+          ),
+        ),
+      )
+      |> toEqual({"variousScalars": expected});
     });
 
     test("Decodes a record in an external fragment", () => {


### PR DESCRIPTION
### What
The Bucklescript 6.x AST seems to be stricter when creating tuples with a single value. When decoding an object with a single field and adding `@bsRecord` to it, the ppx would generate tuples of decoders for each field in the object requested. This causes the ppx to crash in bsb6 with this error
```
 We've found a bug for you!
  (No file name)
  
  broken invariant in parsetree: Tuples must have at least 2 components.
```

This succeeds in bsb5

### Fix
By changing the `generate_record_decoder` to check if the number of fields in the record is `> 1` we can decide if we want a tuple or if we want the decoder and value to be a single value instead.

### Compiled code comparison
_ES5 before bugfix_
```js
function parse$1(value) {
  var value$1 = Js_option.getExn(Js_json.decodeObject(value));
  var match = Js_dict.get(value$1, "variousScalars");
  var tmp;
  if (match !== undefined) {
    var value$2 = Caml_option.valFromOption(match);
    var match$1 = Js_json.decodeObject(value$2);
    if (match$1 !== undefined) {
      var match$2 = Js_dict.get(Caml_option.valFromOption(match$1), "nullableString");
      var field_nullableString;
      if (match$2 !== undefined) {
        var value$3 = Caml_option.valFromOption(match$2);
        var match$3 = Js_json.decodeNull(value$3);
        if (match$3 !== undefined) {
          field_nullableString = undefined;
        } else {
          var match$4 = Js_json.decodeString(value$3);
          field_nullableString = match$4 !== undefined ? match$4 : Js_exn.raiseError("graphql_ppx: Expected string, got " + JSON.stringify(value$3));
        }
      } else {
        field_nullableString = undefined;
      }
      tmp = /* record */[/* nullableString */field_nullableString];
    } else {
      tmp = Js_exn.raiseError("graphql_ppx: Expected object of type VariousScalars, got " + JSON.stringify(value$2));
    }
  } else {
    tmp = Js_exn.raiseError("graphql_ppx: Field variousScalars on type Query is missing");
  }
  return {
          variousScalars: tmp
        };
}
```

_ES5 after bugfix_
```js
function parse$1(value) {
  var value$1 = Js_option.getExn(Js_json.decodeObject(value));
  var match = Js_dict.get(value$1, "variousScalars");
  var tmp;
  if (match !== undefined) {
    var value$2 = Caml_option.valFromOption(match);
    var match$1 = Js_json.decodeObject(value$2);
    if (match$1 !== undefined) {
      var match$2 = Js_dict.get(Caml_option.valFromOption(match$1), "nullableString");
      var field_nullableString;
      if (match$2 !== undefined) {
        var value$3 = Caml_option.valFromOption(match$2);
        var match$3 = Js_json.decodeNull(value$3);
        if (match$3 !== undefined) {
          field_nullableString = undefined;
        } else {
          var match$4 = Js_json.decodeString(value$3);
          field_nullableString = match$4 !== undefined ? match$4 : Js_exn.raiseError("graphql_ppx: Expected string, got " + JSON.stringify(value$3));
        }
      } else {
        field_nullableString = undefined;
      }
      tmp = /* record */[/* nullableString */field_nullableString];
    } else {
      tmp = Js_exn.raiseError("graphql_ppx: Expected object of type VariousScalars, got " + JSON.stringify(value$2));
    }
  } else {
    tmp = Js_exn.raiseError("graphql_ppx: Field variousScalars on type Query is missing");
  }
  return {
          variousScalars: tmp
        };
}
```

_ES6 after bugfix_
```js
function parse$1(value) {
  var value$1 = Js_option.getExn(Js_json.decodeObject(value));
  var match = Js_dict.get(value$1, "variousScalars");
  var tmp;
  if (match !== undefined) {
    var value$2 = Caml_option.valFromOption(match);
    var match$1 = Js_json.decodeObject(value$2);
    if (match$1 !== undefined) {
      var match$2 = Js_dict.get(Caml_option.valFromOption(match$1), "nullableString");
      var field_nullableString;
      if (match$2 !== undefined) {
        var value$3 = Caml_option.valFromOption(match$2);
        var match$3 = Js_json.decodeNull(value$3);
        if (match$3 !== undefined) {
          field_nullableString = undefined;
        } else {
          var match$4 = Js_json.decodeString(value$3);
          field_nullableString = match$4 !== undefined ? match$4 : Js_exn.raiseError("graphql_ppx: Expected string, got " + JSON.stringify(value$3));
        }
      } else {
        field_nullableString = undefined;
      }
      tmp = /* record */[/* nullableString */field_nullableString];
    } else {
      tmp = Js_exn.raiseError("graphql_ppx: Expected object of type VariousScalars, got " + JSON.stringify(value$2));
    }
  } else {
    tmp = Js_exn.raiseError("graphql_ppx: Field variousScalars on type Query is missing");
  }
  return {
          variousScalars: tmp
        };
}
```

Given my eyes (and diff tools) are not failing me, I can't see any difference in the output before and after bugfix and all previous tests pass.