### PR TITLE
ci: build linux binary on alpine with static linking

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,6 +1,7 @@
-##################################################
+################################################################################
 # Dockerfile used for building linux/alpine binary
-##################################################
+# taken from https://github.com/anmonteiro/gh-feed-reader/blob/master/Dockerfile
+################################################################################
 
 # start from node image so we can install esy from npm
 FROM node:12-alpine as build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test_and_build_alpine:
-    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }} with alpine Docker
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install-build
         run: |
           esy install 
-          esy b
+          esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
         run: |
           esy b dune runtest -f
@@ -43,7 +43,7 @@ jobs:
       - name: install-build @402
         run: |
           esy @402 install
-          esy @402 b
+          esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5
         run: |
           cd tests_bucklescript

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,6 +17,9 @@ jobs:
         node-version: [12.x]
         os: [ubuntu-latest]
 
+    container:
+      image: node:12.6-alpine
+
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -27,7 +30,6 @@ jobs:
         run: |
           npm install -g esy@latest cross-env
         # OCaml 4.06 and BuckleScript 6
-      - uses: docker://node:12.6-alpine
       - name: install-build
         run: |
           apk --version 
@@ -41,7 +43,6 @@ jobs:
           cd tests_bucklescript
           node ./run.js bsb6
       # OCaml 4.02 and BuckleScript 5
-      - uses: docker://node:12.6-alpine
       - name: install-build @402
         run: |
           apk --version 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
-          cat /etc/alpine-release 
+          alpine -version
           npm install -g esy@latest cross-env
       # OCaml 4.06 and BuckleScript 6
       - name: install-build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,7 +18,6 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: docker://node:12.6-alpine
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -26,11 +25,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
-          alpine -version
           npm install -g esy@latest cross-env
-      # OCaml 4.06 and BuckleScript 6
+        # OCaml 4.06 and BuckleScript 6
+      - uses: docker://node:12.6-alpine
       - name: install-build
         run: |
+          alpine -version
           esy install 
           esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
@@ -41,8 +41,10 @@ jobs:
           cd tests_bucklescript
           node ./run.js bsb6
       # OCaml 4.02 and BuckleScript 5
+      - uses: docker://node:12.6-alpine
       - name: install-build @402
         run: |
+          alpine -version
           esy @402 install
           esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: docker://node:12.6-alpine
       - name: install-build
         run: |
-          cat /etc/alpine-release 
+          apk --version 
           esy install 
           esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
@@ -44,7 +44,7 @@ jobs:
       - uses: docker://node:12.6-alpine
       - name: install-build @402
         run: |
-          cat /etc/alpine-release 
+          apk --version 
           esy @402 install
           esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
 
     container:
-      image: node:12.6-alpine
+      image: cichocinski/node-with-esy:12-alpine
 
     steps:
       - uses: actions/checkout@v1
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
-          npm install -g esy@latest cross-env
+          npm install -g cross-env
         # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,6 +48,11 @@ jobs:
         run: |
           cd tests_bucklescript
           node ./run.js bsb5
+      - name: Upload artifacts ${{ matrix.os }}
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.os }}
+          path: _build/default/src/bucklescript_bin/bin.exe
         env:
           CI: true
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,6 @@ jobs:
         # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |
-          apk --version 
           esy install 
           esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
@@ -45,7 +44,6 @@ jobs:
       # OCaml 4.02 and BuckleScript 5
       - name: install-build @402
         run: |
-          apk --version 
           esy @402 install
           esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,6 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
+          cat /etc/alpine-release 
           npm install -g esy@latest cross-env
       # OCaml 4.06 and BuckleScript 6
       - name: install-build

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,13 +9,55 @@ on:
       - master
 
 jobs:
+  test_and_build_alpine:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [12.x]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: docker://node:12.6-alpine
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: setup
+        run: |
+          npm install -g esy@latest cross-env
+      # OCaml 4.06 and BuckleScript 6
+      - name: install-build
+        run: |
+          esy install 
+          esy b
+      - name: test-native
+        run: |
+          esy b dune runtest -f
+      - name: test-bsb6
+        run: |
+          cd tests_bucklescript
+          node ./run.js bsb6
+      # OCaml 4.02 and BuckleScript 5
+      - name: install-build @402
+        run: |
+          esy @402 install
+          esy @402 b
+      - name: test-bsb5
+        run: |
+          cd tests_bucklescript
+          node ./run.js bsb5
+        env:
+          CI: true
+
   test_and_build:
     name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [12.x]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: docker://node:12.6-alpine
       - name: install-build
         run: |
-          alpine -version
+          cat /etc/alpine-release 
           esy install 
           esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
@@ -44,7 +44,7 @@ jobs:
       - uses: docker://node:12.6-alpine
       - name: install-build @402
         run: |
-          alpine -version
+          cat /etc/alpine-release 
           esy @402 install
           esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,10 @@ jobs:
         node-version: [12.x]
         os: [ubuntu-latest]
 
+    container:
+      image: cichocinski/node-with-esy:12-alpine
+
     steps:
-      - uses: docker://node:12.6-alpine
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -28,7 +30,7 @@ jobs:
       - name: install-build
         run: |
           esy install
-          esy b
+          esy dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-native
         run: |
           esy b dune runtest -f
@@ -45,7 +47,7 @@ jobs:
       - name: install-build @402
         run: |
           esy @402 install
-          esy @402 b
+          esy @402 dune build --root . --only-packages graphql_ppx --ignore-promoted-rules --no-config --profile release-static
       - name: test-bsb5
         run: |
           cd tests_bucklescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,58 @@ on:
       - v*
 
 jobs:
+  test_and_build_alpine:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }} with alpine Docker
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [12.x]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: docker://node:12.6-alpine
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: setup
+        run: |
+          npm install -g esy@latest cross-env
+      # OCaml 4.06 and BuckleScript 6
+      - name: install-build
+        run: |
+          esy install
+          esy b
+      - name: test-native
+        run: |
+          esy b dune runtest -f
+      - name: test-bsb6
+        run: |
+          cd tests_bucklescript
+          node ./run.js bsb6
+      - name: Upload artifacts ${{ matrix.os }}
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.os }}-bsb6
+          path: _build/default/src/bucklescript_bin/bin.exe
+      # OCaml 4.02 and BuckleScript 5
+      - name: install-build @402
+        run: |
+          esy @402 install
+          esy @402 b
+      - name: test-bsb5
+        run: |
+          cd tests_bucklescript
+          node ./run.js bsb5
+      - name: Upload artifacts ${{ matrix.os }}
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.os }}
+          path: _build/default/src/bucklescript_bin/bin.exe
+        env:
+          CI: true
+
   test_and_build:
     name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/402.json
+++ b/402.json
@@ -1,4 +1,5 @@
 {
+  "name": "graphql_ppx",
   "dependencies": {
     "@opam/dune": "*",
     "@opam/result": "*",
@@ -15,7 +16,7 @@
     "ocaml": "~4.2.0"
   },
   "esy": {
-    "build": "refmterr dune build -p graphql_ppx",
+    "build": [["dune", "build", "-p", "#{self.name}"]],
     "buildsInSource": "_build"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+##################################################
+# Dockerfile used for building linux/alpine binary
+##################################################
+
+# start from node image so we can install esy from npm
+FROM node:12-alpine as build
+
+ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
+
+RUN mkdir /esy
+WORKDIR /esy
+
+ENV NPM_CONFIG_PREFIX=/esy
+RUN npm install -g --unsafe-perm @esy-nightly/esy
+
+# now that we have esy installed we need a proper runtime
+
+FROM alpine:3.8 as esy
+
+ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
+
+WORKDIR /
+
+COPY --from=build /esy /esy
+
+RUN apk add --no-cache ca-certificates wget bash curl perl-utils git patch \
+  gcc g++ musl-dev make m4 linux-headers coreutils
+
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk
+RUN apk add --no-cache glibc-2.28-r0.apk
+
+ENV PATH=/esy/bin:$PATH

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,3 @@
+(lang dune 1.1)
+
+(env (release-static (flags (:standard -ccopt -static))))

--- a/esy.json
+++ b/esy.json
@@ -1,4 +1,5 @@
 {
+  "name": "graphql_ppx",
   "dependencies": {
     "@opam/dune": "*",
     "@opam/result": "*",
@@ -17,7 +18,7 @@
     "ocaml": ">= 4.6.0"
   },
   "esy": {
-    "build": "refmterr dune build -p graphql_ppx",
+    "build": [["dune", "build", "-p", "#{self.name}"]],
     "buildsInSource": "_build"
   }
 }

--- a/src/bucklescript/output_bucklescript_unifier.re
+++ b/src/bucklescript/output_bucklescript_unifier.re
@@ -13,7 +13,7 @@ open Output_bucklescript_utils;
 exception Unimplemented(string);
 
 let make_make_fun = (config, variable_defs) => {
-  let make_tuple = (loc, variables, compose) => [%expr
+  let make_tuple = (_loc, _variables, compose) => [%expr
     (
       parse,
       ppx_printed_query,


### PR DESCRIPTION
Because when using `ubuntu-latest` os on GitHub we're creating linux binaries not working with distros like alpine because of linking against `libc`. We have to use alpine for that which will provide binaries compatible with most distros.