### PR TITLE
Support configuration via ppx-flags

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,10 +26,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: setup
-        run: |
-          npm install -g cross-env
-        # OCaml 4.06 and BuckleScript 6
+
+      # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |
           esy install 
@@ -41,6 +39,7 @@ jobs:
         run: |
           cd tests_bucklescript
           node ./run.js bsb6
+
       # OCaml 4.02 and BuckleScript 5
       - name: install-build @402
         run: |
@@ -74,7 +73,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
-          npm install -g esy@latest cross-env
+          npm install -g esy@latest
+
       # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |
@@ -87,6 +87,7 @@ jobs:
         run: |
           cd tests_bucklescript
           node ./run.js bsb6
+
       # OCaml 4.02 and BuckleScript 5
       - name: install-build @402
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: setup
-        run: |
-          npm install -g esy@latest cross-env
+
       # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |
@@ -43,6 +41,7 @@ jobs:
         with:
           name: ${{ matrix.os }}-bsb6
           path: _build/default/src/bucklescript_bin/bin.exe
+
       # OCaml 4.02 and BuckleScript 5
       - name: install-build @402
         run: |
@@ -76,7 +75,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: setup
         run: |
-          npm install -g esy@latest cross-env
+          npm install -g esy@latest
+
       # OCaml 4.06 and BuckleScript 6
       - name: install-build
         run: |
@@ -94,6 +94,7 @@ jobs:
         with:
           name: ${{ matrix.os }}-bsb6
           path: _build/default/src/bucklescript_bin/bin.exe
+
       # OCaml 4.02 and BuckleScript 5
       - name: install-build @402
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Second, add it to `ppx-flags` in your `bsconfig.json`:
 ```
 
 If you're using bs-platform 6.x or above, add this to `bsconfig.json` instead:
+
 ```json
 "ppx-flags": ["@baransu/graphql_ppx_re/ppx6"]
 ```
@@ -256,12 +257,14 @@ type resultType = MyQuery.t;
 
 ### "Type ... doesn't have any fields"
 
-
 Sometimes when working with union types you'll get the following error.
+
 ```
 Fatal error: exception Graphql_ppx_base__Schema.Invalid_type("Type IssueTimelineItems doesn't have any fields")
 ```
+
 This is an example of a query that will result in such error:
+
 ```graphql
 nodes {
   __typename
@@ -276,10 +279,12 @@ nodes {
   }
 }
 ```
+
 This is because we allow querying union fields only in certain cases. GraphQL provides the `__typename` field but it's not present in GraphQL introspection query thus `graphql_ppx_re` doesn't know that this field exists.
 To fix your query simply remove `__typename`. It's added behinds a scene as an implementation detail and serves us as a way to decide which case to select when parsing your query result.
 
 This is an example of a correct query:
+
 ```graphql
 nodes {
   ... on ClosedEvent {
@@ -295,21 +300,33 @@ nodes {
 
 # Configuration
 
-If you need customize certain features of `graphql_ppx_re` you can provide environment variables do so:
+If you need to customize certain features of `graphql_ppx_re` you can provide ppx arguments to do so:
 
-### GRAPHQL_PPX_APOLLO_MODE
+### -apollo-mode
 
-Tells graphql_ppx to add `__typename` to every object in a query. Usefull in case of using `apollo-client`.
+By default `graphql_ppx_re` adds `__typename` only to fields on which we need those informations (Unions and Interfaces). If you want to add `__typename` on every object in a query you can specify it by using `-apollo-mode` in `ppx-flags`. It's usefull in case of using `apollo-client` because of it's cache.
 
-### GRAPHQL_PPX_SCHEMA
+```json
+"ppx-flags": [
+  ["@baransu/graphql_ppx_re/ppx", "-apollo-mode",]
+],
+```
 
-By default graphql_ppx uses `graphql_schema.json` filed from your root directory. You can override it by providing env variable overriding it.
+### -schema
+
+By default `graphql_ppx_re` uses `graphql_schema.json` file from your root directory. You can override it by providing `-schema` argument in `ppx-flags` to overriding it.
+
+```json
+"ppx-flags": [
+  ["@baransu/graphql_ppx_re/ppx", "-schema ../graphql_schema.json"]
+],
+```
 
 # Query specific configuration
 
 If you want to use multiple schemas in your project it can be provided as a secondary config argument in your graphql ppx definition.
 
-```ocaml
+```reason
 module MyQuery = [%graphql
   {|
     query pokemon($id: String, $name: String) {
@@ -340,28 +357,33 @@ This opens up the possibility to use multiple different GraphQL APIs in the same
 ```
 npm install -g esy@latest
 esy @402 install
-esy @402 dune build -p graphql_ppx
+esy @402 b
 # or
 esy install
-esy dune build -p graphql_ppx
+esy b
 ```
 
 ## Running tests
 
 ### BuckleScript
 
+For `bs-platform@5.x`:
+
 ```
 cd tests_bucklescript
 node run.js bsb5
 ```
 
-If you're using bs-platform 6.x
+Or you're using `bs-platform@6.x` or above:
+
 ```
 cd tests_bucklescript
 node run.js bsb6
 ```
 
 ### Native
+
+For native run:
 
 ```
 esy dune runtest -f

--- a/src/base/ppx_config.re
+++ b/src/base/ppx_config.re
@@ -16,6 +16,8 @@ let config_ref = ref(None);
 
 let set_config = config => config_ref := Some(config);
 
+let update_config = update => config_ref := config_ref^ |> Option.map(update);
+
 let verbose_logging = () =>
   (config_ref^ |> Option.unsafe_unwrap).verbose_logging;
 

--- a/src/bucklescript_bin/Bin.re
+++ b/src/bucklescript_bin/Bin.re
@@ -1,4 +1,4 @@
 open Migrate_parsetree;
 open Graphql_ppx_bucklescript;
 
-Driver.run_as_ppx_rewriter();
+let _ = Driver.run_as_ppx_rewriter();

--- a/src/native/graphql_ppx.re
+++ b/src/native/graphql_ppx.re
@@ -139,7 +139,7 @@ let extract_schema_from_config = config_fields => {
   open Parsetree;
 
   let maybe_schema_field =
-    try (
+    try(
       Some(
         List.find(
           config_field =>
@@ -165,117 +165,161 @@ let extract_schema_from_config = config_fields => {
   };
 };
 
-let mapper = (_config, _cookies) => {
-  open Ast_406;
-  open Ast_mapper;
-  open Parsetree;
-  open Asttypes;
-
-  let () =
-    Ppx_config.(
-      set_config({
-        verbose_logging: false,
-        // switch (List.find((==)("-verbose"), argv)) {
-        // | _ => true
-        // | exception Not_found => false
-        // },
-        output_mode: Ppx_config.String,
-        // switch (List.find((==)("-ast-out"), argv)) {
-        // | _ => Ppx_config.Apollo_AST
-        // | exception Not_found =>
-        // },
-        verbose_error_handling:
-          switch (Sys.getenv("NODE_ENV")) {
-          | "production" => false
-          | _ => true
-          | exception Not_found => true
-          },
-        apollo_mode:
-          switch (Sys.getenv("GRAPHQL_PPX_APOLLO_MODE")) {
-          | "true" => true
-          | _ => false
-          | exception Not_found => false
-          },
-        root_directory: Sys.getcwd(),
-        schema_file:
-          switch (Sys.getenv("GRAPHQL_PPX_SCHEMA")) {
-          | arg => arg
-          | exception Not_found => "graphql_schema.json"
-          },
-        raise_error_with_loc: (loc, message) => {
-          let loc = conv_loc(loc);
-          raise(Location.Error(Location.error(~loc, message)));
+// Default configuration
+let () =
+  Ppx_config.(
+    set_config({
+      verbose_logging: false,
+      output_mode: Ppx_config.String,
+      verbose_error_handling:
+        switch (Sys.getenv("NODE_ENV")) {
+        | "production" => false
+        | _ => true
+        | exception Not_found => true
         },
-      })
-    );
-
-  {
-    ...default_mapper,
-    module_expr: (mapper, mexpr) =>
-      switch (mexpr) {
-      | {pmod_desc: Pmod_extension(({txt: "graphql", loc}, pstr)), _} =>
-        switch (pstr) {
-        | PStr([
-            {
-              pstr_desc:
-                Pstr_eval(
-                  {
-                    pexp_loc: loc,
-                    pexp_desc: Pexp_constant(Pconst_string(query, delim)),
-                    _,
-                  },
-                  _,
-                ),
-              _,
-            },
-            {
-              pstr_desc:
-                Pstr_eval({pexp_desc: Pexp_record(fields, None), _}, _),
-              _,
-            },
-          ]) =>
-          let maybe_schema = extract_schema_from_config(fields);
-          rewrite_query(
-            ~schema=?maybe_schema,
-            ~loc=conv_loc_from_ast(loc),
-            ~delim,
-            ~query,
-            (),
-          );
-        | PStr([
-            {
-              pstr_desc:
-                Pstr_eval(
-                  {
-                    pexp_loc: loc,
-                    pexp_desc: Pexp_constant(Pconst_string(query, delim)),
-                    _,
-                  },
-                  _,
-                ),
-              _,
-            },
-          ]) =>
-          rewrite_query(~loc=conv_loc_from_ast(loc), ~delim, ~query, ())
-        | _ =>
-          raise(
-            Location.Error(
-              Location.error(
-                ~loc,
-                "[%graphql] accepts a string, e.g. [%graphql {| { query |}]",
-              ),
-            ),
-          )
-        }
-      | other => default_mapper.module_expr(mapper, other)
+      apollo_mode: false,
+      schema_file: "graphql_schema.json",
+      root_directory: Sys.getcwd(),
+      raise_error_with_loc: (loc, message) => {
+        let loc = conv_loc(loc);
+        raise(Location.Error(Location.error(~loc, message)));
       },
-  };
+    })
+  );
+
+let mapper = (_config, _cookies) => {
+  Ast_406.(
+    Ast_mapper.(
+      Parsetree.(
+        Asttypes.{
+          ...default_mapper,
+          module_expr: (mapper, mexpr) =>
+            switch (mexpr) {
+            | {pmod_desc: Pmod_extension(({txt: "graphql", loc}, pstr)), _} =>
+              switch (pstr) {
+              | PStr([
+                  {
+                    pstr_desc:
+                      Pstr_eval(
+                        {
+                          pexp_loc: loc,
+                          pexp_desc:
+                            Pexp_constant(Pconst_string(query, delim)),
+                          _,
+                        },
+                        _,
+                      ),
+                    _,
+                  },
+                  {
+                    pstr_desc:
+                      Pstr_eval(
+                        {pexp_desc: Pexp_record(fields, None), _},
+                        _,
+                      ),
+                    _,
+                  },
+                ]) =>
+                let maybe_schema = extract_schema_from_config(fields);
+                rewrite_query(
+                  ~schema=?maybe_schema,
+                  ~loc=conv_loc_from_ast(loc),
+                  ~delim,
+                  ~query,
+                  (),
+                );
+              | PStr([
+                  {
+                    pstr_desc:
+                      Pstr_eval(
+                        {
+                          pexp_loc: loc,
+                          pexp_desc:
+                            Pexp_constant(Pconst_string(query, delim)),
+                          _,
+                        },
+                        _,
+                      ),
+                    _,
+                  },
+                ]) =>
+                rewrite_query(
+                  ~loc=conv_loc_from_ast(loc),
+                  ~delim,
+                  ~query,
+                  (),
+                )
+              | _ =>
+                raise(
+                  Location.Error(
+                    Location.error(
+                      ~loc,
+                      "[%graphql] accepts a string, e.g. [%graphql {| { query |}]",
+                    ),
+                  ),
+                )
+              }
+            | other => default_mapper.module_expr(mapper, other)
+            },
+        }
+      )
+    )
+  );
 };
 
+let args = [
+  (
+    "-verbose",
+    Arg.Unit(
+      () =>
+        Ppx_config.update_config(current =>
+          {...current, verbose_logging: true}
+        ),
+    ),
+    "Defines if logging should be verbose or not",
+  ),
+  (
+    "-apollo-mode",
+    Arg.Unit(
+      () =>
+        Ppx_config.update_config(current => {...current, apollo_mode: true}),
+    ),
+    "Defines if apply Apollo specific code generation",
+  ),
+  (
+    "-schema",
+    Arg.String(
+      schema_file =>
+        Ppx_config.update_config(current => {...current, schema_file}),
+    ),
+    "<path/to/schema.json>",
+  ),
+  (
+    "-ast-out",
+    Arg.Bool(
+      ast_out =>
+        Ppx_config.update_config(current =>
+          {
+            ...current,
+            output_mode: ast_out ? Ppx_config.Apollo_AST : Ppx_config.String,
+          }
+        ),
+    ),
+    "Defines if output string or AST",
+  ),
+  (
+    "-o",
+    Arg.Unit(
+      () =>
+        Ppx_config.update_config(current =>
+          {...current, verbose_error_handling: true}
+        ),
+    ),
+    "Verbose error handling. If not defined NODE_ENV will be used",
+  ),
+];
+
 let () =
-  Migrate_parsetree.Driver.register(
-    ~name="graphql",
-    ~args=[],
-    Migrate_parsetree.Versions.ocaml_406,
-    mapper,
+  Migrate_parsetree.(
+    Driver.register(~name="graphql", ~args, Versions.ocaml_406, mapper)
   );

--- a/tests_bucklescript/bsb5/bsconfig.json
+++ b/tests_bucklescript/bsb5/bsconfig.json
@@ -1,7 +1,13 @@
 {
   "name": "tests_bucklescript",
   "sources": ["__tests__"],
-  "ppx-flags": ["../_build/default/src/bucklescript_bin/bin.exe"],
+  "ppx-flags": [
+    [
+      "../_build/default/src/bucklescript_bin/bin.exe",
+      "-apollo-mode=true",
+      "-schema=../graphql_schema.json"
+    ]
+  ],
   "bs-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3,
   "bsc-flags": ["-bs-super-errors"],

--- a/tests_bucklescript/bsb5/bsconfig.json
+++ b/tests_bucklescript/bsb5/bsconfig.json
@@ -4,8 +4,8 @@
   "ppx-flags": [
     [
       "../_build/default/src/bucklescript_bin/bin.exe",
-      "-apollo-mode=true",
-      "-schema=../graphql_schema.json"
+      "-apollo-mode",
+      "-schema ../graphql_schema.json"
     ]
   ],
   "bs-dependencies": ["@glennsl/bs-jest"],

--- a/tests_bucklescript/bsb5/package-lock.json
+++ b/tests_bucklescript/bsb5/package-lock.json
@@ -916,9 +916,9 @@
       }
     },
     "bs-platform": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.0.6.tgz",
-      "integrity": "sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-5.2.1.tgz",
+      "integrity": "sha512-3ISP+RBC/NYILiJnphCY0W3RTYpQ11JGa2dBBLVug5fpFZ0qtSaL3ZplD8MyjNeXX2bC7xgrWfgBSn8Tc9om7Q==",
       "dev": true
     },
     "bser": {

--- a/tests_bucklescript/bsb5/package.json
+++ b/tests_bucklescript/bsb5/package.json
@@ -2,7 +2,7 @@
   "name": "ppx_example",
   "version": "0.1.0",
   "scripts": {
-    "test": "cross-env GRAPHQL_PPX_APOLLO_MODE=true GRAPHQL_PPX_SCHEMA=../graphql_schema.json bsb -clean-world -make-world && jest --verbose lib/js",
+    "test": "bsb -clean-world -make-world && jest --verbose lib/js",
     "generate-schema": "node ./node_modules/gql-tools/cli/gqlschema.js -o graphql_schema.json schema.graphql"
   },
   "keywords": [

--- a/tests_bucklescript/bsb5/package.json
+++ b/tests_bucklescript/bsb5/package.json
@@ -11,8 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.5",
-    "bs-platform": "5.0.6",
-    "cross-env": "^5.2.1",
+    "bs-platform": "~5.2.0",
     "gql-tools": "^0.0.15",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.6.1",

--- a/tests_bucklescript/bsb6/bsconfig.json
+++ b/tests_bucklescript/bsb6/bsconfig.json
@@ -1,7 +1,13 @@
 {
   "name": "tests_bucklescript",
   "sources": ["__tests__"],
-  "ppx-flags": ["../_build/default/src/bucklescript_bin/bin.exe"],
+  "ppx-flags": [
+    [
+      "../_build/default/src/bucklescript_bin/bin.exe",
+      "-apollo-mode=true",
+      "-schema=../graphql_schema.json"
+    ]
+  ],
   "bs-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3,
   "bsc-flags": ["-bs-super-errors"],

--- a/tests_bucklescript/bsb6/bsconfig.json
+++ b/tests_bucklescript/bsb6/bsconfig.json
@@ -4,8 +4,8 @@
   "ppx-flags": [
     [
       "../_build/default/src/bucklescript_bin/bin.exe",
-      "-apollo-mode=true",
-      "-schema=../graphql_schema.json"
+      "-apollo-mode",
+      "-schema ../graphql_schema.json"
     ]
   ],
   "bs-dependencies": ["@glennsl/bs-jest"],

--- a/tests_bucklescript/bsb6/package-lock.json
+++ b/tests_bucklescript/bsb6/package-lock.json
@@ -916,9 +916,9 @@
       }
     },
     "bs-platform": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-6.0.3.tgz",
-      "integrity": "sha512-zptjWiSaioLVbEq0n3LPwfn1nyY3qt8fXzdI1O+yj6a6sBKmtT2kcx9oXJZl/cuLUnVumXKpb5ksTsYztbJPUg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-7.0.1.tgz",
+      "integrity": "sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==",
       "dev": true
     },
     "bser": {

--- a/tests_bucklescript/bsb6/package.json
+++ b/tests_bucklescript/bsb6/package.json
@@ -2,10 +2,12 @@
   "name": "ppx_example",
   "version": "0.1.0",
   "scripts": {
-    "test": "GRAPHQL_PPX_APOLLO_MODE=true GRAPHQL_PPX_SCHEMA=../graphql_schema.json  bsb -clean-world -make-world && ./node_modules/.bin/jest --verbose lib/js",
+    "test": "bsb -clean-world -make-world && ./node_modules/.bin/jest --verbose lib/js",
     "generate-schema": "node ./node_modules/gql-tools/cli/gqlschema.js -o graphql_schema.json schema.graphql"
   },
-  "keywords": ["BuckleScript"],
+  "keywords": [
+    "BuckleScript"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.5",

--- a/tests_bucklescript/bsb6/package.json
+++ b/tests_bucklescript/bsb6/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.5",
-    "bs-platform": "6.0.3",
+    "bs-platform": "~7.0.1",
     "gql-tools": "^0.0.15",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.6.1",


### PR DESCRIPTION
When migrating to the current version of `Migrate_parsetree` I've removed `ppx-flags` based configuration (i.e ppx arguments).

This PR resolves #40 brings back configuration in `ppx-flags` in `bsconfig.json` and removes support for env variables. It's a breaking change and will result in "major" version bump (i.e minor because of pre 1.0.0 versioning we're using right now).